### PR TITLE
Fix menu borders for when there is no compositor running

### DIFF
--- a/gtk-3.0/gtk.css
+++ b/gtk-3.0/gtk.css
@@ -703,9 +703,9 @@ filechooserbutton:drop(active) {
 
 menu, .menu {
   margin: 4px;
-  padding: 0;
+  padding: 1px;
   border-radius: 0px;
-  border-style: none;
+  border: 1px solid #989898;
   color: #000000;
   background-color: #D7D7D7; }
   .csd menu, .csd .menu {


### PR DESCRIPTION
Hi Christian, thanks for your amazing work on the themes!

I am running pekwm without a compositor and noticed that the menus didn't have an outline around them:

![was](https://github.com/B00merang-Project/Haiku/assets/58649917/46cfe606-d39e-4336-92b4-491a1ee6c792)

I've added a simple fix:

![fixed](https://github.com/B00merang-Project/Haiku/assets/58649917/0df0dd5b-3cac-44d2-9769-9e231597cbfc)
